### PR TITLE
Added type in AccessToken clear function

### DIFF
--- a/lib/angular2/shared/services/core/auth.ejs
+++ b/lib/angular2/shared/services/core/auth.ejs
@@ -64,7 +64,7 @@ export class LoopBackAuth {
   }
   
   public clear(): void {
-    Object.keys(this.token).forEach(prop => StorageDriver.remove(`${this.prefix}${prop}`));
+    Object.keys(this.token).forEach((prop: string) => StorageDriver.remove(`${this.prefix}${prop}`));
     this.token = new SDKToken();
   }
   // I do not persist everything in 1 value because I want


### PR DESCRIPTION
When generating the SDK, the angular project would complain about 'prop' not having a type in the clear function for the Auth service if the 'noImplicitAny' flag is used in the TS compiler . I made a small change in auth.ejs to add the type string to prop.

Old
`Object.keys(this.token).forEach(prop => StorageDriver.remove(`${this.prefix}${prop}`));`

New
`Object.keys(this.token).forEach((prop: string) => StorageDriver.remove(`${this.prefix}${prop}`));`