### PR TITLE
Added support for loopback http context checking

### DIFF
--- a/lib/angular2/index.js
+++ b/lib/angular2/index.js
@@ -219,7 +219,8 @@ module.exports = function generate(ctx) {
             buildMethodParams: buildMethodParams,
             buildServiceImports: buildServiceImports,
             normalizeMethodName: normalizeMethodName,
-            buildObservableType: buildObservableType
+            buildObservableType: buildObservableType,
+            paramIsContext: paramIsContext
           }
         }
       ]);
@@ -464,6 +465,11 @@ module.exports = function generate(ctx) {
     let availableClasses = relations.map((relationName, index) =>
       model.sharedClass.ctor.relations[relationName].targetClass
     );
+
+    params = params.filter(param => {
+      return !paramIsContext(param)
+    });
+
     relations.forEach(relationName => {
         if (model.sharedClass.ctor.relations[relationName].modelThrough) {
           let throughName = capitalize(
@@ -530,6 +536,14 @@ module.exports = function generate(ctx) {
     return typeof param.http === 'function'
   }
   /**
+   * @method paramIsContext
+   * @description
+   * Testing if the param is a http.context
+   */
+  function paramIsContext(param) {
+    return (typeof param.http !== 'undefined' && typeof param.http.source !== 'undefined' && param.http.source === 'context');
+  }
+  /**
    * @method buildPostBody
    * @description
    * Define which properties should be passed while posting data (POST, PUT, PATCH)
@@ -566,7 +580,7 @@ module.exports = function generate(ctx) {
     // filter params that should not go over url query string
     urlParams = urlParams.filter(param => {
         // Filter out route params and function params
-        if (paramIsRoute(param) || paramIsFunction(param)) {
+        if (paramIsRoute(param) || paramIsFunction(param) || paramIsContext(param)) {
           return false
         }
         // Filter out body params

--- a/lib/angular2/shared/services/custom/service.ejs
+++ b/lib/angular2/shared/services/custom/service.ejs
@@ -218,14 +218,17 @@ action.description =  '<em>\n' +
 } -%>
    * <%-: action.description | replace:/\n/g, '\n         * ' %>
 <%
-var params = action.accepts;
+var params = action.accepts.filter(param => {
+    return !paramIsContext(param);
+});
+
 var postData;
 if (httpVerb == 'POST' || httpVerb == 'PUT' || httpVerb == 'PATCH') {
   params = params.filter(function(arg) {
     return arg.http && (arg.http.source == 'query' || arg.http.source == 'path');
   });
   postData = action.accepts.filter(function(arg) {
-    return params.indexOf(arg) == -1;
+    return params.indexOf(arg) == -1 && !paramIsContext(arg);
   });
 }
 -%>

--- a/tests/angular2/common/models/room.js
+++ b/tests/angular2/common/models/room.js
@@ -18,7 +18,7 @@ module.exports = function (Room) {
   Room.findByRoom = (room, next) => {
     next(null, room);
   };
-  
+
   Room.remoteMethod(
     'findByRoom',
     {
@@ -35,7 +35,7 @@ module.exports = function (Room) {
   Room.greetPost = (b1, b2, b3, next) => {
     next(null, `${b1.a}:${b2.b}:${b3.c}`);
   };
-  
+
   Room.remoteMethod(
     'greetPost',
     {
@@ -78,6 +78,35 @@ module.exports = function (Room) {
       ],
       returns: { arg: 'greeting', type: 'string' },
       http: { path: '/slimshady', verb: 'get' }
+    }
+  );
+
+  /**
+   * Mock endpoint thta checks to see if we can read the context and returns a valid result to test it.
+   * @param room
+   * @param context
+   * @param next
+   */
+  Room.findByRoomContext = function(room, context, next){
+    var host = (typeof(context.req) !== 'undefined' && typeof(context.req.hostname) !== 'undefined' ? context.req.hostname : false);
+
+    if(host) {
+      room.name += host;
+    } else {
+      room = {id: -1, name: ""};
+    }
+    next(null, room);
+  };
+
+  Room.remoteMethod(
+    'findByRoomContext',
+    {
+      accepts: [
+        { arg: 'room', type: 'object', http: { source: 'body' }},
+        { arg: 'remoteCtx', description: '**Do not implement in clients**.', type: Object, injectCtx: true, http: { source: 'context' }}
+      ],
+      returns: { arg: 'room', type: 'object', root: true },
+      http: { path: '/findByRoomContext', verb: 'post' }
     }
   );
 };

--- a/tests/angular2/loopback/config.json
+++ b/tests/angular2/loopback/config.json
@@ -4,7 +4,7 @@
   "port": 3000,
   "remoting": {
     "context": {
-      "enableHttpContext": false
+      "enableHttpContext": true
     },
     "rest": {
       "normalizeHttpPath": false,

--- a/tests/angular2/src/app/room-service.service.spec.ts
+++ b/tests/angular2/src/app/room-service.service.spec.ts
@@ -260,4 +260,21 @@ describe('Service: Room Service', () => {
         })))));
     })
   ));
+
+  /**
+   * This test is to validate that contexts support is working
+   * i modify the name of the room appending the host to the name if it works
+   * if it doesn't work i set room.id = -1 and the name to blank
+   */
+  it('should find by mock room to test custom remote method with context enabled',
+    async(inject([RoomApi], (roomApi: RoomApi) => {
+        let room = new Room({ id: 42, name: 'my awesome room' });
+        return roomApi.findByRoomContext(room)
+          .subscribe((instance: Room) => {
+            expect(room.id).toBe(instance.id);
+            // I append the host onto the instance name so it shouldn't match now
+            expect(room.name).not.toBe(instance.name);
+          });
+      })
+    ));
 });


### PR DESCRIPTION
The client shouldn't ever know about context, so we'll go ahead and
exclude it from the required methods as well as the documentation
generation.

This adds 1 new function paramIsContext and uses that in the buildMethodParams and buildUrlParams functions of the lib/angular2/index.js

It also exposes the function to the service.ejs for use in the documentation section for filtering out the documentation on the params and on the postData.

This pull request contains the previous 3 commits rebased into one commit to make it cleaner.