### PR TITLE
Fixing issue #260

### DIFF
--- a/lib/angular2/shared/services/core/base.ejs
+++ b/lib/angular2/shared/services/core/base.ejs
@@ -180,7 +180,7 @@ export abstract class BaseLoopBackApi {
       LoopBackConfig.getPath(),
       LoopBackConfig.getApiVersion(),
       this.model.getModelDefinition().plural,
-      'exists'
+      ':id/exists'
     ].join('/'), { id }, undefined, undefined);
   }
   /**


### PR DESCRIPTION
Route was missing `:id` for `exists` method

#### What type of pull request are you creating?
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?

None

Write a reason if none (e.g just fixed a typo):

Just fixed a missing param in the URL, tested locally

#### Please add a description for your pull request:

See issue #260 