### PR TITLE
change AccessToken to SDKToken

### DIFF
--- a/lib/angular2/shared/services/core/auth.ejs
+++ b/lib/angular2/shared/services/core/auth.ejs
@@ -31,8 +31,8 @@ export class LoopBackAuth {
     this.token.rememberMe = value;
   }
 
-  public getToken(): AccessToken {
-    return <AccessToken> this.token;
+  public getToken(): SDKToken {
+    return <SDKToken> this.token;
   }
 
   public getAccessTokenId(): any {


### PR DESCRIPTION
the getToken() method returns this.token, which is of class SDKToken.

#### What type of pull request are you creating?
- [x ] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?


Write a reason if none (e.g just fixed a typo):


#### Please add a description for your pull request: