### PR TITLE
Fix for values that contain '='

### DIFF
--- a/lib/angular2/shared/storage/cookie.browser.ts
+++ b/lib/angular2/shared/storage/cookie.browser.ts
@@ -18,7 +18,7 @@ export class CookieBrowser {
         return null;
       }
 
-      this.cookies[key] = this.parse(cookie.split('=').pop());
+      this.cookies[key] = this.parse(cookie.split('=').slice(1).join('='));
     }
 
     return this.cookies[key];


### PR DESCRIPTION
Values stored in the cookie might contain the '='. The pop-method will only return the string after the last occurence which can especially damage JSON encoded data and cause an application to crash. This change should fix it.

#### What type of pull request are you creating?
- Bug Fix