### PR TITLE
Option to change InternalStorage provider for ng2web

### DIFF
--- a/lib/angular2/index.js
+++ b/lib/angular2/index.js
@@ -531,7 +531,7 @@ module.exports = function generate(ctx) {
     switch (environment) {
       case 'browser':
         if (driver === 'ng2web' || driver === 'ng2universal') {
-          imports.push('{ provide: InternalStorage, useClass: CookieBrowser }');
+          imports.push('internalStorageProvider');
           imports.push('{ provide: SDKStorage, useClass: StorageBrowser }');
           if (isIo === 'enabled') {
             imports.push('{ provide: SocketDriver, useClass: SocketBrowser }');

--- a/lib/angular2/shared/index.ejs
+++ b/lib/angular2/shared/index.ejs
@@ -53,7 +53,10 @@
   ]
 })
 export class SDKBrowserModule {
-  static forRoot(): ModuleWithProviders {
+  static forRoot(internalStorageProvider: any = {
+    provide: InternalStorage,
+    useClass: CookieBrowser
+  }): ModuleWithProviders {
     return {
       ngModule  : SDKBrowserModule,
       providers : [
@@ -120,4 +123,8 @@ export class SDKNativeModule {
 export * from './models/index';
 export * from './services/index';
 export * from './lb.config';
-
+<% if ( driver === 'ng2web' ) { -%>
+export * from './storage/storage.swaps';
+export { CookieBrowser } from './storage/cookie.browser';
+export { StorageBrowser } from './storage/storage.browser';
+<% } -%>


### PR DESCRIPTION
#### What type of pull request are you creating?
- [ ] Bug Fix
- [x] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?


Write a reason if none (e.g just fixed a typo):


#### Please add a description for your pull request:
Keeps default behaviour but now it is possible to change InternalStorage provider when importing.

```
SDKBrowserModule.forRoot({
  provide: InternalStorage,
  useClass: StorageBrowser
})
```