### PR TITLE
Fix LoggerService time and timeEnd

### DIFF
--- a/lib/angular2/shared/services/core/logger.ejs
+++ b/lib/angular2/shared/services/core/logger.ejs
@@ -53,11 +53,11 @@ export class LoggerService {
 
   time(arg: string) {
     if (LoopBackConfig.debuggable())
-    console.count(arg);
+    console.time(arg);
   }
 
   timeEnd(arg: string) {
     if (LoopBackConfig.debuggable())
-    console.count(arg);
+    console.timeEnd(arg);
   }
 }


### PR DESCRIPTION
#### What type of pull request are you creating?
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?
0

Write a reason if none (e.g just fixed a typo):
Simple fix

#### Please add a description for your pull request:
LoggerService.time and ...timeEnd were set to output count instead of elapsed time.