### PR TITLE
TS2365 Error Fix

### DIFF
--- a/lib/angular2/shared/services/core/search.ejs
+++ b/lib/angular2/shared/services/core/search.ejs
@@ -31,14 +31,16 @@ export class JSONSearchParams {
     }
 
     private _parseParam(key: string, value: any, parent: string) {
-        if (typeof value !== 'object' && typeof value !== 'array') {
-            return parent ? parent + '[' + key + ']=' + value
-                          : key + '=' + value;
-        } else if (typeof value === 'object' ||  typeof value === 'array') {
-            return parent ? this._JSON2URL(value, parent + '[' + key + ']')
-                          : this._JSON2URL(value, key);
-        } else {
-            throw new Error('Unexpected Type');
-        }
+      if ((<string>(typeof value) !== 'object') &&
+          (<string>(typeof value) !== 'array')) {
+          return parent ? parent + '[' + key + ']=' + value
+                        : key + '=' + value;
+      } else if ((<string>(typeof value) === 'object') ||
+                 (<string>(typeof value) === 'array')) {
+          return parent ? this._JSON2URL(value, parent + '[' + key + ']')
+                        : this._JSON2URL(value, key);
+      } else {
+          throw new Error('Unexpected Type');
+      }
     }
 }


### PR DESCRIPTION
TS in Angular is very strict on type and throws an error from the typeof call, this fix forces the results of the typeof call to be a string.

The errors thrown up on the original code are 

sdk/services/core/search.params.ts(34,42): error TS2365: Operator '!==' cannot be applied to types '"string" | "number" | "boolean" | "symbol" | "undefined" | "object" | "function"' and '"array"'.

and

sdk/services/core/search.params.ts(37,50): error TS2365: Operator '===' cannot be applied to types '"string" | "number" | "boolean" | "symbol" | "undefined" | "object" | "function"' and '"array"'.