### PR TITLE
fix typescript 2.2+ 'Operator '!==' cannot be applied to types' error

### DIFF
--- a/lib/angular2/shared/services/core/search.ejs
+++ b/lib/angular2/shared/services/core/search.ejs
@@ -31,14 +31,14 @@ export class JSONSearchParams {
     }
 
     private _parseParam(key: string, value: any, parent: string) {
-        if (typeof value !== 'object' && typeof value !== 'array') {
+        let typeofValue:string = typeof value;
+
+        if (typeofValue !== 'object' && typeofValue !== 'array') {
             return parent ? parent + '[' + key + ']=' + value
                           : key + '=' + value;
-        } else if (typeof value === 'object' ||  typeof value === 'array') {
+        } else {
             return parent ? this._JSON2URL(value, parent + '[' + key + ']')
                           : this._JSON2URL(value, key);
-        } else {
-            throw new Error('Unexpected Type');
         }
     }
 }


### PR DESCRIPTION
#### What type of pull request are you creating?
- [X] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?
none

Write a reason if none (e.g just fixed a typo):
program compiles under 2.2 with update, does not without

#### Please add a description for your pull request:

fixes the issue #371 _Operator '!==' cannot be applied to types_ compile error with typescript 2.2+