### PR TITLE
Fix #396: buildPropertyType method fix

### DIFF
--- a/lib/angular2/index.js
+++ b/lib/angular2/index.js
@@ -832,8 +832,8 @@ module.exports = function generate(ctx) {
    * @description
    * Define which properties should be passed as route params
    */
-  function buildPropertyType(property) {
-    if (!property.type) {
+  function buildPropertyType(type) {
+    if (type.type) {
       return 'any';
     } 
     switch (typeof type) {


### PR DESCRIPTION
Changes argument for buildPropertyType to "type" and also update property.type
check to type.type check.

#### What type of pull request are you creating?
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?


Write a reason if none (e.g just fixed a typo):


#### Please add a description for your pull request: