### PR TITLE
* [bug] the cached cookie forget to remove on the borwser.

### DIFF
--- a/lib/angular2/shared/storage/cookie.browser.ts
+++ b/lib/angular2/shared/storage/cookie.browser.ts
@@ -58,6 +58,7 @@ export class CookieBrowser {
    **/
   remove(key: string) {
     document.cookie = key + '=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+    delete this.cookies[key];
   }
   /**
    * @method parse


### PR DESCRIPTION
- [X] Bug Fix
- [ ] Enhancement
- [ ] Documentation



Write a reason if none (e.g just fixed a typo):

just fixed a little glitch to logout on browser.



It should remove the cached item after the cookie removed.