### PR TITLE
Fixes return type on BaseLoopBackApi.exists method

### DIFF
--- a/lib/angular2/shared/services/core/base.ejs
+++ b/lib/angular2/shared/services/core/base.ejs
@@ -186,7 +186,7 @@ export abstract class BaseLoopBackApi {
    * @description
    * Generic exists method
    */
-  public exists<T>(id: any): Observable<T[]> {
+  public exists<T>(id: any): Observable<T> {
     return this.request('GET', [
       LoopBackConfig.getPath(),
       LoopBackConfig.getApiVersion(),

--- a/tests/ng2web/src/app/room-service.service.spec.ts
+++ b/tests/ng2web/src/app/room-service.service.spec.ts
@@ -18,6 +18,7 @@ describe('Service: Room Service', () => {
     async(inject([RoomApi], (service: RoomApi) => {
       expect(service).toBeTruthy();
       expect(service.create).toBeTruthy();
+      expect(service.exists).toBeTruthy();
       expect(service.updateAll).toBeTruthy();
       expect(service.updateAttributes).toBeTruthy();
       expect(service.find).toBeTruthy();
@@ -322,5 +323,27 @@ describe('Service: Room Service', () => {
             expect(room.name).not.toBe(instance.name);
           });
       })
+    ));
+
+  it('should return correct response if the room does not exist',
+    async(inject([RoomApi], (roomApi: RoomApi) => {
+      return roomApi.exists<{ exists: boolean }>(42)
+        .subscribe((result) => {
+          expect(result.exists).toBe(false);
+        });
+    })
+    ));
+
+  it('should return correct response if the room does not exist',
+    async(inject([RoomApi], (roomApi: RoomApi) => {
+      let room: Room = new Room();
+      room.name = Date.now().toString();
+      return roomApi
+        .create(room)
+        .switchMap((instance: Room) => roomApi.exists<{ exists: boolean }>(instance.id))
+        .subscribe((result: { exists: boolean }) => {
+          expect(result.exists).toBe(true);
+        });
+    })
     ));
 });


### PR DESCRIPTION
#### What type of pull request are you creating?
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?
2

Write a reason if none (e.g just fixed a typo):


#### Please add a description for your pull request:
fixes https://github.com/mean-expert-official/loopback-sdk-builder/issues/433

changed:
```
// lib/angular2/shared/services/core/base.ejs:189

from:
public exists<T>(id: any): Observable<T[]> {
to:
public exists<T>(id: any): Observable<T> {
```