### PR TITLE
Replaced importing  { Observable } from 'rxjs/Rx'  to 'rxjs/Observabl…

### DIFF
--- a/lib/angular2/index.js
+++ b/lib/angular2/index.js
@@ -451,7 +451,7 @@ module.exports = function generate(ctx) {
       { module: 'JSONSearchParams', from: '../core/search.params'},
       { module: 'ErrorHandler', from: '../core/error.service'},
       { module: 'Subject', from: 'rxjs/Subject'},
-      { module: 'Observable', from: 'rxjs/Rx'},
+      { module: 'Observable', from: 'rxjs/Observable'},
       { module: modelName, from: `../../models/${modelName}`},
     ];
     if (isIo === 'enabled') {

--- a/lib/angular2/shared/models/flref.ts
+++ b/lib/angular2/shared/models/flref.ts
@@ -1,5 +1,5 @@
 import { Subject } from 'rxjs/Subject';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { LoopBackFilter, StatFilter } from './index';
 import { SocketConnection } from '../sockets/socket.connections';
 /**

--- a/lib/angular2/shared/services/core/realtime.ts
+++ b/lib/angular2/shared/services/core/realtime.ts
@@ -5,7 +5,7 @@ import { LoopBackConfig } from '../../lb.config';
 import { FireLoop } from '../../models/FireLoop';
 import { SocketConnection } from '../../sockets/socket.connections';
 import { SDKModels } from '../custom/SDKModels';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { Subscription } from 'rxjs/Subscription';
 /**


### PR DESCRIPTION
…e'. Prevents importing all rxjs operators in angular projects, to reduce build size

#### What type of pull request are you creating?
- [ ] Bug Fix

#### How many unit test did you write for this pull request?
0
Write a reason if none (e.g just fixed a typo):
Does not change functionality

#### Please add a description for your pull request:
Observable was imported from 'rxjs/Rx', which imports all rxjs operators. Fixed it by changing to importing from 'rxjs/Observable'
