### PR TITLE
fix: blacklist methods are now preserved instead of emptied immediately

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,8 +36,12 @@ exports.describeModels = function describeModels(app) {
     // Tell SDK Builder to generate model by default, unless user 
     c.sharedClass.ctor.settings = Object.assign(
       {},
-      c.sharedClass.ctor.settings,
-      { sdk: { enabled: true }}
+      c.sharedClass.ctor.settings
+    );
+    c.sharedClass.ctor.settings.sdk = Object.assign(
+      {},
+      c.sharedClass.ctor.settings.sdk,
+      {enabled: true}
     );
     // Tell SDK to blacklist specific methods
     c.sharedClass.ctor.settings.sdk.blacklist = Object.assign(


### PR DESCRIPTION
#### What type of pull request are you creating?
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?
0

Write a reason if none (e.g just fixed a typo):
I could not find tests in the original branch to build upon

#### Please add a description for your pull request:
The blacklist functionality didn't work because the first assignment to settings with the defaults {sdk: {enabled: true }} would overwrite any blacklist settings of the user. Made the assignments less destructive so it works