### PR TITLE
Quick fix for #478

### DIFF
--- a/lib/angular2/index.js
+++ b/lib/angular2/index.js
@@ -387,7 +387,7 @@ module.exports = function generate(ctx) {
     // the password property anymore but is required for TypeScript purposes
     if (model.isUser && !model.properties.password) {
       model.properties.password = {
-        type: model.properties.username.type
+        type: String
       }
     }
     // Add Model Properties


### PR DESCRIPTION
#### What type of pull request are you creating?
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?
None

Write a reason if none (e.g just fixed a typo): Username's type is string, I just make it string directly instead of getting type of model.username


#### Please add a description for your pull request: When the username is hidden/redefined SDK Builder fails to retrieve its options (#478), so we cant get username's type. Password property type should be string we can directly say that without referencing username's type.