### PR TITLE
Added option to enable the 'withCredentials' argument for the angular `RequestOptions` class

### DIFF
--- a/lib/angular2/shared/config.ejs
+++ b/lib/angular2/shared/config.ejs
@@ -82,4 +82,12 @@ export class LoopBackConfig {
   public static isSecureWebSocketsSet(): boolean {
     return LoopBackConfig.secure;
   }
+
+  public static setRequestOptionsCredentials(withCredentials: boolean = false): void {
+    LoopBackConfig.withCredentials = withCredentials;
+  }
+
+  public static getRequestOptionsCredentials(): boolean {
+    return LoopBackConfig.withCredentials;
+  }
 }

--- a/lib/angular2/shared/config.ejs
+++ b/lib/angular2/shared/config.ejs
@@ -26,6 +26,7 @@ export class LoopBackConfig {
   private static debug: boolean = true;
   private static filterOn: string = 'headers';
   private static secure: boolean = false;
+  private static withCredentials: boolean = false;
 
   public static setApiVersion(version: string = 'api'): void {
     LoopBackConfig.version = version;

--- a/lib/angular2/shared/services/core/base.ejs
+++ b/lib/angular2/shared/services/core/base.ejs
@@ -104,12 +104,12 @@ export abstract class BaseLoopBackApi {
       this.searchParams.setJSON(urlParams);
       let request: Request = new Request(
         new RequestOptions({
-          headers : headers,
-          method  : method,
-          url     : `${url}${filter}`,
-          search  : Object.keys(urlParams).length > 0
-                  ? this.searchParams.getURLSearchParams() : null,
-          body    : body ? JSON.stringify(body) : undefined
+          headers        : headers,
+          method         : method,
+          url            : `${url}${filter}`,
+          search         : Object.keys(urlParams).length > 0 ? this.searchParams.getURLSearchParams() : null,
+          body           : body ? JSON.stringify(body) : undefined,
+          withCredentials: LoopBackConfig.getRequestOptionsCredentials()
         })
       );
       return this.http.request(request)


### PR DESCRIPTION
#### What type of pull request are you creating?
- [ ] Bug Fix
- [x] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?
0

Write a reason if none (e.g just fixed a typo):
I could not get the current unit tests working. 

#### Please add a description for your pull request:
Added options to enable the "XMLHttpRequest.withCredentials" using the LoopBackConfig.

[Ref docs](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials): "The XMLHttpRequest.withCredentials property is a Boolean that indicates whether or not cross-site Access-Control requests should be made using credentials such as cookies, authorization headers or TLS client certificates. Setting withCredentials has no effect on same-site requests."