### PR TITLE
capitalize(param.type) crashes with param.type being undefined

### DIFF
--- a/lib/angular2/index.js
+++ b/lib/angular2/index.js
@@ -710,7 +710,7 @@ module.exports = function generate(ctx) {
       if (param.type === 'object') {
         type = param.arg === 'filter' ? 'LoopBackFilter' : 'any';
       } else {
-        type = param.type !== 'AccessToken' && param.type !== 'any'
+        type = param.type !== 'AccessToken' && param.type !== 'any' && param.type !== undefined
           ? capitalize(param.type) : 'any';
       }
       if (!type.match(/(^any$|LoopBackFilter)/) && availableClasses.indexOf(type) < 0) {


### PR DESCRIPTION
#### What type of pull request are you creating?
- [X] Bug Fix

#### How many unit test did you write for this pull request?
None

Write a reason if none (e.g just fixed a typo):
It crashes I want it to stop crashing

#### Please add a description for your pull request:
It's really just what it says in the tiny commit message. 
Don't want to call capitalize() in that case.