### PR TITLE
Fix/ngrx imports

### DIFF
--- a/lib/angular2/shared/actions/auth.ejs
+++ b/lib/angular2/shared/actions/auth.ejs
@@ -34,82 +34,82 @@ export const LoopbackAuthActionTypes = {
  * @description
  * Provides with a LoopBack compatible authentication actions.
  */
-export const LoopbackAuthActions = {
-  loadToken: class implements Action {
+export namespace LoopbackAuthActions {
+  export class loadToken implements Action {
     public readonly type = LoopbackAuthActionTypes.LOAD_TOKEN;
-  },
+  }
 
-  loadTokenSuccess: class implements Action {
+  export class loadTokenSuccess implements Action {
     public readonly type = LoopbackAuthActionTypes.LOAD_TOKEN_SUCCESS;
 
     constructor(public payload: SDKToken, public meta?: any) { }
-  },
+  }
 
-  loadTokenFail: class implements Action {
+  export class loadTokenFail implements Action {
     public readonly type = LoopbackAuthActionTypes.LOAD_TOKEN_FAIL;
 
     constructor(public payload: any, public meta?: any) { }
-  },
+  }
 
-  setToken: class implements Action {
+  export class setToken implements Action {
     public readonly type = LoopbackAuthActionTypes.SET_TOKEN;
 
     constructor(public payload: SDKToken, public meta?: any) { }
-  },
+  }
 
-  setTokenSuccess: class implements Action {
+  export class setTokenSuccess implements Action {
     public readonly type = LoopbackAuthActionTypes.SET_TOKEN_SUCCESS;
 
     constructor(public payload: SDKToken, public meta?: any) { }
-  },
+  }
 
-  clearToken: class implements Action {
+  export class clearToken implements Action {
     public readonly type = LoopbackAuthActionTypes.CLEAR_TOKEN;
-  },
+  }
 
-  setUser: class implements Action {
+  export class setUser implements Action {
     public readonly type = LoopbackAuthActionTypes.SET_USER;
 
     constructor(public payload: any, public meta?: any) { }
-  },
+  }
 
-  setUserSuccess: class implements Action {
+  export class setUserSuccess implements Action {
     public readonly type = LoopbackAuthActionTypes.SET_USER_SUCCESS;
 
     constructor(public payload: any, public meta?: any) { }
-  },
+  }
 
-  updateUserProperties: class implements Action {
+  export class updateUserProperties implements Action {
     public readonly type = LoopbackAuthActionTypes.UPDATE_USER_PROPERTIES;
 
     constructor(public payload: any, public meta?: any) { }
-  },
+  }
 
-  updateUserPropertiesSuccess: class implements Action {
+  export class updateUserPropertiesSuccess implements Action {
     public readonly type = LoopbackAuthActionTypes.UPDATE_USER_PROPERTIES_SUCCESS;
 
     constructor(public payload: any, public meta?: any) { }
-  },
+  }
 
-  updateUserPropertiesFail: class implements Action {
+  export class updateUserPropertiesFail implements Action {
     public readonly type = LoopbackAuthActionTypes.UPDATE_USER_PROPERTIES_FAIL;
 
     constructor(public payload: any, public meta?: any) { }
-  },
+  }
 
-  updateUserState: class implements Action {
+  export class updateUserState implements Action {
     public readonly type = LoopbackAuthActionTypes.UPDATE_USER_STATE;
 
     constructor(public payload: any, public meta?: any) { }
-  },
+  }
 
-  updateUserStateSuccess: class implements Action {
+  export class updateUserStateSuccess implements Action {
     public readonly type = LoopbackAuthActionTypes.UPDATE_USER_STATE_SUCCESS;
 
     constructor(public payload: any, public meta?: any) { }
-  },
+  }
 
-  guardFail: class implements Action {
+  export class guardFail implements Action {
     public readonly type = LoopbackAuthActionTypes.GUARD_FAIL;
-  },
-};
+  }
+}

--- a/lib/angular2/shared/actions/error.ejs
+++ b/lib/angular2/shared/actions/error.ejs
@@ -20,8 +20,8 @@ export const LoopbackErrorActionTypes = {
  * @description
  * Provides with a LoopBack error actions to centralize error message handling.
  */
-export const LoopbackErrorActions = {
-  error: class implements Action {
+export namespace LoopbackErrorActions {
+  export class error implements Action {
     public readonly type = LoopbackErrorActionTypes.ERROR;
 
     constructor(public payload: any, public meta?: any) { }

--- a/lib/angular2/shared/effects/auth.ejs
+++ b/lib/angular2/shared/effects/auth.ejs
@@ -1,6 +1,7 @@
 /* tslint:disable */
 import { map, catchError, startWith, mergeMap } from 'rxjs/operators'
 import { of } from 'rxjs/observable/of';
+import { Observable } from 'rxjs/Observable';
 import { concat } from 'rxjs/observable/concat';
 import { Injectable } from '@angular/core';
 import { Effect, Actions } from '@ngrx/effects';

--- a/lib/angular2/shared/effects/auth.ejs
+++ b/lib/angular2/shared/effects/auth.ejs
@@ -69,7 +69,7 @@ export class LoopbackAuthEffects {
     .pipe(
       mergeMap((action: LoopbackAction) => {
         const token = this.auth.getToken();
-        return this.user.patchAttributes(token.userId, action.payload)
+        return this.user.updateAttributes(token.userId, action.payload)
           .pipe(
             map((response) => {
               this.auth.setToken(Object.assign({}, this.auth.getToken(), {

--- a/lib/angular2/shared/effects/base.ejs
+++ b/lib/angular2/shared/effects/base.ejs
@@ -2,6 +2,7 @@
 import { map, catchError, mergeMap } from 'rxjs/operators'
 import { of } from 'rxjs/observable/of';
 import { concat } from 'rxjs/observable/concat';
+import { Observable } from 'rxjs/Observable';
 import { Actions } from '@ngrx/effects';
 import { resolver } from './resolver';
 import { LoopbackAction } from '../models/BaseModels';

--- a/lib/angular2/shared/effects/model.ejs
+++ b/lib/angular2/shared/effects/model.ejs
@@ -3,6 +3,7 @@ import { map, catchError, mergeMap } from 'rxjs/operators'
 import { of } from 'rxjs/observable/of';
 import { concat } from 'rxjs/observable/concat';
 import { Injectable, Inject } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
 import { Effect, Actions } from '@ngrx/effects';
 
 import { LoopbackAction } from '../models/BaseModels';

--- a/lib/angular2/shared/orm/base.ejs
+++ b/lib/angular2/shared/orm/base.ejs
@@ -1,10 +1,11 @@
 /* tslint:disable */
 <% if (isIo === 'enabled') { %>
-import { map, finalize } from 'rxjs/operators'
+import { finalize } from 'rxjs/operators'
 import { AsyncSubject } from 'rxjs/AsyncSubject';
 import { RealTime } from '../services';
 import { createIO } from './io';
 <% } %>
+import { map } from 'rxjs/operators'
 import { Observable } from 'rxjs/Observable';
 import { Store } from '@ngrx/store';
 

--- a/lib/angular2/shared/reducers/base.ejs
+++ b/lib/angular2/shared/reducers/base.ejs
@@ -1,6 +1,7 @@
 /* tslint:disable */
 import { EntityAdapter } from '@ngrx/entity';
 import { LoopbackAction } from '../models/BaseModels';
+import { Observable } from 'rxjs/Observable';
 import * as filterNodes from 'loopback-filters';
 
 /**

--- a/lib/angular2/shared/reducers/model.ejs
+++ b/lib/angular2/shared/reducers/model.ejs
@@ -1,5 +1,5 @@
 /* tslint:disable */
-import { Action, createSelector } from '@ngrx/store';
+import { Action, MemoizedSelector, createSelector } from '@ngrx/store';
 import { EntityState, EntityAdapter, createEntityAdapter } from '@ngrx/entity';
 import { BaseReducerFactory } from './base';
 import { <%- modelName %>, <%- modelName %>Interface } from '../models';

--- a/lib/angular2/shared/state.ejs
+++ b/lib/angular2/shared/state.ejs
@@ -1,14 +1,15 @@
 /* tslint:disable */
 import { SDKToken } from './models/BaseModels';
 
-import * as reducers from './reducers/index';
 
 import { LoopbackAuthEffects } from './effects/auth';
+import { LoopbackAuthReducer } from './reducers/auth';
 <% for (var modelName in models) {
   // capitalize the model name
   modelName = modelName[0].toUpperCase() + modelName.slice(1);
 -%>
 import { <%- modelName %>Effects } from './effects/<%- modelName %>';
+import { <%- modelName %>sState, <%- modelName %>sReducer } from './reducers/<%- modelName %>';
 <% } // for modelName in models -%>
 
 export interface LoopbackStateInterface {
@@ -17,17 +18,17 @@ export interface LoopbackStateInterface {
   // capitalize the model name
   modelName = modelName[0].toUpperCase() + modelName.slice(1);
 -%>
-  <%- modelName %>s: reducers.<%- modelName %>sState;
+  <%- modelName %>s: <%- modelName %>sState;
 <% } // for modelName in models -%>
 };
 
 export const LoopbackReducer = {
-  LoopbackAuth: reducers.LoopbackAuthReducer,
+  LoopbackAuth: LoopbackAuthReducer,
 <% for (var modelName in Object.assign({}, models, throughModels)) {
   // capitalize the model name
   modelName = modelName[0].toUpperCase() + modelName.slice(1);
 -%>
-	<%- modelName %>s: reducers.<%- modelName %>sReducer,
+	<%- modelName %>s: <%- modelName %>sReducer,
 <% } // for modelName in models -%>
 };
 

--- a/lib/angular2/shared/state.ejs
+++ b/lib/angular2/shared/state.ejs
@@ -4,6 +4,8 @@ import { SDKToken } from './models/BaseModels';
 
 import { LoopbackAuthEffects } from './effects/auth';
 import { LoopbackAuthReducer } from './reducers/auth';
+import { LoopbackAction } from './models/base';
+
 <% for (var modelName in models) {
   // capitalize the model name
   modelName = modelName[0].toUpperCase() + modelName.slice(1);

--- a/lib/angular2/shared/state.ejs
+++ b/lib/angular2/shared/state.ejs
@@ -1,10 +1,8 @@
 /* tslint:disable */
-import { SDKToken } from './models/BaseModels';
-
+import { SDKToken, LoopbackAction } from './models/BaseModels';
 
 import { LoopbackAuthEffects } from './effects/auth';
 import { LoopbackAuthReducer } from './reducers/auth';
-import { LoopbackAction } from './models/base';
 
 <% for (var modelName in models) {
   // capitalize the model name


### PR DESCRIPTION
#### What type of pull request are you creating?
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?
- 0

Write a reason if none (e.g just fixed a typo):
Just adding additional imports.

#### Please add a description for your pull request:
When building a ngrx version with the latest typecsript/angular/etc I received quite a few compile errors in the format of:

`Public property {foo} of exported class has or is using name {bar} from external module {baz} but cannot be named.`

The crux of it came down to definition files not being able to build for things like `import { map } from 'rxjs/operators/map` without also importing `{Observable} from 'rxjs/Observable`.

The reason for the change from exporting an object to a namespace for auth actions was a similar type of error:

`Public property '{foo}$' of exported class has or is using name '(Anonymous class)' from external module` in `effects/auth.ts`.