### PR TITLE
Fix Socket.IO type

### DIFF
--- a/lib/angular2/shared/sockets/socket.native.ts
+++ b/lib/angular2/shared/sockets/socket.native.ts
@@ -18,7 +18,7 @@ export class SocketNative {
    * @description
    * This method will return a valid socket connection.                    
    **/
-  connect(url: string, options: any): SocketIO.Socket {
+  connect(url: string, options: any): SocketIO.SocketIO {
     return SocketIO.connect(url, options);
   }
 }


### PR DESCRIPTION
#### What type of pull request are you creating?
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?


Write a reason if none (e.g just fixed a typo):
Just fixed a type

#### Please add a description for your pull request:

At least with the latest version of `nativescript-socket.io`, which is `0.9.0`, NativeScript throws the following error, as the former does not export `Socket` anymore but `SocketIO` instead:

`app/sdk/sockets/socket.native.ts(21,48): error TS2694: Namespace '"/Users/mariano/work/example/mobile-src/HelloWorld/node_modules/nativescript-socket.io/index"' has no exported member 'Socket'.`
