### PR TITLE
Fix error Unexpected end of JSON input

### DIFF
--- a/lib/angular2/shared/services/core/base.ejs
+++ b/lib/angular2/shared/services/core/base.ejs
@@ -113,7 +113,7 @@ export abstract class BaseLoopBackApi {
         })
       );
       return this.http.request(request)
-        .map((res: any) => (res.text() != "" ? res.json() : {}))
+        .map((res: any) => ((res && res.text() != "") ? res.json() : {}))
         .catch((e) => this.errorHandler.handleError(e));
     }
   }


### PR DESCRIPTION
for HEAD requests the sdk throw an error: for HEAD requests

#### What type of pull request are you creating?
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### Description:
For HEAD requests (without body), I get an error:

```
Uncaught (in promise): SyntaxError: Unexpected end of JSON input
SyntaxError: Unexpected end of JSON input
```  

Stack: 
```
export class ErrorHandler {
  // ErrorObservable when rxjs version < rc.5
  // ErrorObservable<string> when rxjs version = rc.5
  // I'm leaving any for now to avoid breaking apps using both versions
  public handleError(error: Response): any {
->    return Observable.throw(error.json().error || 'Server error');
  }
}

```

```
          withCredentials: LoopBackConfig.getRequestOptionsCredentials()
        })
      );
      return this.http.request(request)
        .map((res: any) => (res.text() != "" ? res.json() : {}))
->        .catch((e) => this.errorHandler.handleError(e));
    }
  }
  /**
   * @method authenticate
   * @author Jonathan Casarrubias <t: johncasarrubias, gh: mean-expert-official>
```