### PR TITLE
Encode plus signs in search params of requests

### DIFF
--- a/lib/angular2/shared/services/core/search.ejs
+++ b/lib/angular2/shared/services/core/search.ejs
@@ -1,6 +1,6 @@
 /* tslint:disable */
 import { Injectable } from '@angular/core';
-import { URLSearchParams } from '@angular/http';
+import { URLSearchParams, QueryEncoder } from '@angular/http';
 /**
 * @author Jonathan Casarrubias <twitter:@johncasarrubias> <github:@mean-expert-official>
 * @module JSONSearchParams
@@ -10,13 +10,25 @@ import { URLSearchParams } from '@angular/http';
 * This module correctly encodes a json object into a query string and then creates
 * an instance of the URLSearchParams component for later use in HTTP Calls
 **/
+
+class CustomQueryEncoderHelper extends QueryEncoder {
+    encodeKey(k: string): string {
+        k = super.encodeKey(k);
+        return k.replace(/\+/gi, '%2B');
+    }
+    encodeValue(v: string): string {
+        v = super.encodeValue(v);
+        return v.replace(/\+/gi, '%2B');
+    }
+}
+
 @Injectable()
 export class JSONSearchParams {
 
     private _usp: URLSearchParams;
 
     public setJSON(obj: any) {
-        this._usp = new URLSearchParams(this._JSON2URL(obj, false));
+        this._usp = new URLSearchParams(this._JSON2URL(obj, false), new CustomQueryEncoderHelper());
     }
 
     public getURLSearchParams(): URLSearchParams {


### PR DESCRIPTION
#### What type of pull request are you creating?
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?

I do not really know how to test this at the moment. Maybe someone can give me a hint where to start? Then I will update the PR with tests.

#### Please add a description for your pull request:

This fix encodes plus signs in the Angular SDK when they are sent as search params. Currently, Angular does not encode plus signs, they are received as empty space on the Loopback side. I applied the fix that is described here:

https://github.com/angular/angular/issues/11058#issuecomment-292457108

