### PR TITLE
Add custom encoder for HTTP params

### DIFF
--- a/lib/angular2/shared/services/core/base.ejs
+++ b/lib/angular2/shared/services/core/base.ejs
@@ -2,6 +2,23 @@
 <%- buildBaseServiceImports(isIo)  %>
 // Making Sure EventSource Type is available to avoid compilation issues.
 declare var EventSource: any;
+class CustomQueryEncoderHelper implements HttpParameterCodec {
+  encodeKey(k: string): string {
+      return encodeURIComponent(k);
+  }
+
+  encodeValue(v: string): string {
+      return encodeURIComponent(v);
+  }
+
+  decodeKey(k: string): string {
+      return decodeURIComponent(k);
+  }
+
+  decodeValue(v: string): string {
+      return decodeURIComponent(v);
+  }
+}
 /**
 * @module BaseLoopBackApi
 * @author Jonathan Casarrubias <@johncasarrubias> <github:jonathan-casarrubias>
@@ -63,7 +80,7 @@ export abstract class BaseLoopBackApi {
       console.info('SDK: PubSub functionality is disabled, generate SDK using -io enabled');
 <% } -%>
     } else {
-      let httpParams = new HttpParams();
+      let httpParams = new HttpParams({ encoder: new CustomQueryEncoderHelper() });
       // Headers to be sent
       let headers: HttpHeaders = new HttpHeaders();
       headers = headers.append('Content-Type', 'application/json');


### PR DESCRIPTION
#### What type of pull request are you creating?
- [x] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?

I do not really know how to test this at the moment. Maybe someone can give me a hint where to start? Then I will update the PR with tests.

#### Please add a description for your pull request:

This fix encodes special characters in parameters, as for example the plus sign, in the Angular SDK when they are sent as search params. Currently, Angular does not encode plus signs, they are received as empty space on the Loopback side. I applied the fix that is described here:

angular/angular#11058 (comment)