### PR TITLE
fix: no more error with referencesMany relation

### DIFF
--- a/lib/angular2/shared/effects/model.ejs
+++ b/lib/angular2/shared/effects/model.ejs
@@ -71,13 +71,17 @@ export class <%- modelName %>Effects extends BaseLoopbackEffects {
       <% } else if (methodName.match(/(^__link)/) && model.sharedClass.ctor.relations[action.name.split('__').pop()].targetClass) {
         var rel = action.name.split('__').pop(); -%>
     mergeMap((response: any) => concat(
+          <% if (model.sharedClass.ctor.relations[rel].modelThrough) { -%>
           of(new actions['<%- capitalize(model.sharedClass.ctor.relations[rel].modelThrough.definition.name) %>Actions'].createSuccess(response, action.meta)),
+          <% } -%>
           of(new <%- modelName %>Actions.<%- normalizeMethodName(methodName) %>Success(action.payload.id, response, action.meta))
         )),
       <% } else if (methodName.match(/(^__unlink)/) && model.sharedClass.ctor.relations[action.name.split('__').pop()].targetClass) {
         var rel = action.name.split('__').pop(); -%>
     mergeMap((response: any) => concat(
+          <% if (model.sharedClass.ctor.relations[rel].modelThrough) { -%>
           of(new actions['<%- capitalize(model.sharedClass.ctor.relations[rel].modelThrough.definition.name) %>Actions'].deleteByIdSuccess(response.id, action.meta)),
+           <% } -%>
           of(new <%- modelName %>Actions.<%- normalizeMethodName(methodName) %>Success(action.payload.id, response, action.meta))
         )),
       <% } else if (!action.returns || action.returns.length == 0) { -%>


### PR DESCRIPTION
#### What type of pull request are you creating?
- [X] Bug Fix
- [ ] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?
none. just fix

#### Please add a description for your pull request:
There is no "modelThrough" when use referencesMany relation. So, this fix error when generating ngrx effects for model with referencesMany relation.