### PR TITLE
fix(sdk): RxJS imports comply to v6

### DIFF
--- a/lib/angular2/index.js
+++ b/lib/angular2/index.js
@@ -800,8 +800,7 @@ module.exports = function generate(ctx) {
         from: '../../models/BaseModels'
       },
       { module: 'ErrorHandler', from: '../core/error.service'},
-      { module: 'Subject', from: 'rxjs/Subject'},
-      { module: 'Observable', from: 'rxjs/Observable'},
+      { module: 'Observable, Subject', from: 'rxjs'},
       { module: 'map', from: 'rxjs/operators' },
       { module: modelName, from: `../../models/${modelName}`},
     ];
@@ -977,9 +976,7 @@ module.exports = function generate(ctx) {
       { module: 'LoopBackConfig', from: '../../lb.config'},
       { module: 'LoopBackFilter, AccessToken', from: '../../models/BaseModels'},
       { module: 'SDKModels', from: '../custom/SDKModels'},
-      { module: 'Observable', from: 'rxjs/Observable' },
-      { module: 'Subject', from: 'rxjs/Subject' },
-      { module: 'ErrorObservable', from: 'rxjs/observable/ErrorObservable' },
+      { module: 'Observable, Subject', from: 'rxjs' },
       { module: 'catchError, map, filter', from: 'rxjs/operators' },
     ];
 

--- a/lib/angular2/shared/effects/auth.ejs
+++ b/lib/angular2/shared/effects/auth.ejs
@@ -1,7 +1,6 @@
 /* tslint:disable */
+import { concat, of } from 'rxjs';
 import { map, catchError, startWith, mergeMap } from 'rxjs/operators'
-import { of } from 'rxjs/observable/of';
-import { concat } from 'rxjs/observable/concat';
 import { Injectable } from '@angular/core';
 import { Effect, Actions } from '@ngrx/effects';
 

--- a/lib/angular2/shared/effects/base.ejs
+++ b/lib/angular2/shared/effects/base.ejs
@@ -1,7 +1,6 @@
 /* tslint:disable */
+import { concat, of } from 'rxjs';
 import { map, catchError, mergeMap } from 'rxjs/operators'
-import { of } from 'rxjs/observable/of';
-import { concat } from 'rxjs/observable/concat';
 import { Actions } from '@ngrx/effects';
 import { resolver } from './resolver';
 import { LoopbackAction } from '../models/BaseModels';

--- a/lib/angular2/shared/effects/model.ejs
+++ b/lib/angular2/shared/effects/model.ejs
@@ -1,7 +1,6 @@
 /* tslint:disable */
-import { map, catchError, mergeMap } from 'rxjs/operators'
-import { of } from 'rxjs/observable/of';
-import { concat } from 'rxjs/observable/concat';
+import { concat, of } from 'rxjs';
+import { map, catchError, mergeMap } from 'rxjs/operators';
 import { Injectable, Inject } from '@angular/core';
 import { Effect, Actions } from '@ngrx/effects';
 

--- a/lib/angular2/shared/guards/auth.guard.ejs
+++ b/lib/angular2/shared/guards/auth.guard.ejs
@@ -1,6 +1,5 @@
 /* tslint:disable */
-import { Observable } from 'rxjs/Observable';
-import { of } from 'rxjs/observable/of';
+import { Observable, of } from 'rxjs';
 import { flatMap } from 'rxjs/operators'
 import { Injectable } from '@angular/core';
 import { CanActivate } from '@angular/router';

--- a/lib/angular2/shared/guards/model.ejs
+++ b/lib/angular2/shared/guards/model.ejs
@@ -1,10 +1,9 @@
 /* tslint:disable */
+import { Observable, of } from 'rxjs';
 import { take, map, switchMap, catchError } from 'rxjs/operators'
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { CanActivate, ActivatedRouteSnapshot } from '@angular/router';
-import { Observable } from 'rxjs/Observable';
-import { of } from 'rxjs/observable/of';
 
 import { <%- modelName %>Api } from '../services/index';
 import { get<%- modelName %>ById } from '../reducers/<%- modelName %>';

--- a/lib/angular2/shared/models/flref.ts
+++ b/lib/angular2/shared/models/flref.ts
@@ -1,9 +1,6 @@
 /* tslint:disable */
-import 'rxjs/add/observable/merge';
-import { Subject } from 'rxjs/Subject';
-import { Observable } from 'rxjs/Observable';
+import { merge, Observable, Subject } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import 'rxjs/add/operator/merge';
 import { LoopBackFilter, StatFilter } from './index';
 import { SocketConnection } from '../sockets/socket.connections';
 /**
@@ -158,7 +155,7 @@ export class FireLoopRef<T> {
       request = { filter, parent: this.parent.instance };
     }
     if (event.match(/(value|change|stats)/)) {
-      return Observable.merge(
+      return merge(
         this.pull(event, request),
         this.broadcasts(event, request)
       );

--- a/lib/angular2/shared/orm/base.ejs
+++ b/lib/angular2/shared/orm/base.ejs
@@ -1,12 +1,12 @@
 /* tslint:disable */
 <% if (isIo === 'enabled') { %>
 import { finalize } from 'rxjs/operators'
-import { AsyncSubject } from 'rxjs/AsyncSubject';
+import { AsyncSubject } from 'rxjs';
 import { RealTime } from '../services';
 import { createIO } from './io';
 <% } %>
 import { map } from 'rxjs/operators'
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
 import { Store } from '@ngrx/store';
 
 import { applyFilter, toArray } from './filter';

--- a/lib/angular2/shared/orm/filter.ejs
+++ b/lib/angular2/shared/orm/filter.ejs
@@ -1,11 +1,11 @@
 /* tslint:disable */
-import { map, publishReplay, combineLatest, withLatestFrom, auditTime, refCount } from 'rxjs/operators'
-import { Observable } from 'rxjs/Observable'
-import * as filterNodes from 'loopback-filters'
+import { map, publishReplay, combineLatest, withLatestFrom, auditTime, refCount } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import * as filterNodes from 'loopback-filters';
 
-import * as models from '../models'
+import * as models from '../models';
 
-import { LoopBackFilter } from '../models'
+import { LoopBackFilter } from '../models';
 
 export function applyFilter(state$: Observable<any>, filters: LoopBackFilter, store: any, model: any): Observable<any> {
   return include(

--- a/lib/angular2/shared/orm/io.ejs
+++ b/lib/angular2/shared/orm/io.ejs
@@ -1,13 +1,13 @@
 /* tslint:disable */
-import { map, takeUntil, finalize } from 'rxjs/operators'
-import { AsyncSubject } from 'rxjs/AsyncSubject'
-import { Store } from '@ngrx/store'
+import { map, takeUntil, finalize } from 'rxjs/operators';
+import { AsyncSubject } from 'rxjs';
+import { Store } from '@ngrx/store';
 
-import { RealTime } from '../services'
-import { resolver } from '../effects/resolver'
+import { RealTime } from '../services';
+import { resolver } from '../effects/resolver';
 
-import * as models from '../models'
-import { LoopBackFilter, FireLoopRef } from '../models'
+import * as models from '../models';
+import { LoopBackFilter, FireLoopRef } from '../models';
 
 export function createIO(
   filter: LoopBackFilter,

--- a/lib/angular2/shared/orm/models/model.ejs
+++ b/lib/angular2/shared/orm/models/model.ejs
@@ -1,12 +1,12 @@
 /* tslint:disable */
 <% if (isIo === 'enabled') { %>
+import { AsyncSubject } from 'rxjs';
 import { finalize } from 'rxjs/operators';
-import { AsyncSubject } from 'rxjs/AsyncSubject';
 import { RealTime } from '../../services';
 import { createIO } from '../io';
 <% } %>
+import { Observable } from 'rxjs';
 import { map, combineLatest } from 'rxjs/operators';
-import { Observable } from 'rxjs/Observable';
 import { Store } from '@ngrx/store';
 
 import { OrmBase } from '../base';

--- a/lib/angular2/shared/resolvers/auth-account.ejs
+++ b/lib/angular2/shared/resolvers/auth-account.ejs
@@ -1,5 +1,5 @@
 /* tslint:disable */
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
 import { Injectable } from '@angular/core';
 import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
 import { Store } from '@ngrx/store';

--- a/lib/angular2/shared/services/core/error.ejs
+++ b/lib/angular2/shared/services/core/error.ejs
@@ -1,18 +1,13 @@
 /* tslint:disable */
 import { Injectable } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Observable } from 'rxjs/Observable';
-//import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
-import 'rxjs/add/observable/throw';
+import { Observable, throwError } from 'rxjs';
 /**
  * Default error handler
  */
 @Injectable()
 export class ErrorHandler {
-  // ErrorObservable when rxjs version < rc.5
-  // ErrorObservable<string> when rxjs version = rc.5
-  // I'm leaving any for now to avoid breaking apps using both versions
-  public handleError(errorResponse: HttpErrorResponse): any {
-    return Observable.throw(errorResponse.error.error || 'Server error');
+  public handleError(errorResponse: HttpErrorResponse): Observable<never> {
+    return throwError(errorResponse.error.error || 'Server error');
   }
 }

--- a/lib/angular2/shared/services/core/io.ejs
+++ b/lib/angular2/shared/services/core/io.ejs
@@ -1,6 +1,5 @@
 /* tslint:disable */
-import { Subject } from 'rxjs/Subject';
-import { Observable } from 'rxjs/Observable';
+import { Observable, Subject } from 'rxjs';
 
 export class IO {
 

--- a/lib/angular2/shared/services/core/realtime.ts
+++ b/lib/angular2/shared/services/core/realtime.ts
@@ -5,10 +5,8 @@ import { LoopBackAuth } from './auth.service';
 import { FireLoop } from '../../models/FireLoop';
 import { SocketConnection } from '../../sockets/socket.connections';
 import { SDKModels } from '../custom/SDKModels';
-import { Observable } from 'rxjs/Observable';
+import { Observable, Subject, Subscription } from 'rxjs';
 import { share } from 'rxjs/operators';
-import { Subject } from 'rxjs/Subject';
-import { Subscription } from 'rxjs/Subscription';
 /**
 * @author Jonathan Casarrubias <twitter:@johncasarrubias> <github:@johncasarrubias>
 * @module RealTime

--- a/lib/angular2/shared/sockets/connections.ts
+++ b/lib/angular2/shared/sockets/connections.ts
@@ -2,8 +2,7 @@
 import { Injectable, Inject, NgZone } from '@angular/core';
 import { SocketDriver } from './socket.driver';
 import { AccessToken } from '../models';
-import { Subject } from 'rxjs/Subject';
-import { Observable } from 'rxjs/Observable';
+import { Observable, Subject } from 'rxjs';
 import { share } from 'rxjs/operators';
 import { LoopBackConfig } from '../lb.config';
 /**

--- a/lib/react/react-builders.js
+++ b/lib/react/react-builders.js
@@ -99,9 +99,7 @@ exports.buildBaseServiceImports = (isIo) => {
     { module: 'LoopBackConfig', from: '../../lb.config' },
     { module: 'LoopBackFilter, AccessToken', from: '../../models/BaseModels' },
     { module: 'SDKModels', from: '../custom/SDKModels' },
-    { module: 'Observable', from: 'rxjs/Observable' },
-    { module: 'Subject', from: 'rxjs/Subject' },
-    { module: 'ErrorObservable', from: 'rxjs/observable/ErrorObservable' },
+    { module: 'Observable, Subject', from: 'rxjs' },
     { module: 'catchError, map', from: 'rxjs/operators' },
   ];
 
@@ -251,8 +249,7 @@ exports.buildServiceImports = (model, loadAccessToken, isIo, models) => {
     },
     { module: 'JSONSearchParams', from: '../core/search.params' },
     { module: 'ErrorHandler', from: '../core/error.service' },
-    { module: 'Subject', from: 'rxjs/Subject' },
-    { module: 'Observable', from: 'rxjs/Rx' },
+    { module: 'Observable, Subject', from: 'rxjs' },
     { module: modelName, from: `../../models/${modelName}` },
   ];
   if (isIo === 'enabled') {

--- a/lib/templates/shared/models/flref.ts
+++ b/lib/templates/shared/models/flref.ts
@@ -1,7 +1,5 @@
-import { Subject } from 'rxjs/Subject';
-import { Observable } from 'rxjs/Observable';
+import { merge, Observable, Subject } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import 'rxjs/add/observable/merge';
 import { LoopBackFilter, StatFilter } from './index';
 import { SocketConnection } from '../sockets/socket.connections';
 /**

--- a/lib/templates/shared/services/core/base.ejs
+++ b/lib/templates/shared/services/core/base.ejs
@@ -4,7 +4,7 @@
 declare var EventSource: any;
 <% if (framework === 'react') { %>
 import axios from 'axios';
-import 'rxjs/add/observable/fromPromise';
+import { from } from 'rxjs';
 <% } %>
 /**
 * @module BaseLoopBackApi
@@ -174,7 +174,7 @@ let headers = {
           data    : body ? JSON.stringify(body) : undefined
         }
       );
-      return Observable.fromPromise(request)
+      return from(request)
         .map((res) => res.data)
         .catch((e) => errorHandler.handleError(e));
 <% } %>
@@ -683,7 +683,7 @@ let headers = {
 <%- buildBaseServiceImports(isIo)  %>
 <% if (framework === 'react') { %>
 import axios from 'axios';
-import 'rxjs/add/observable/fromPromise';
+import { from } from 'rxjs';
 <% } %>
 /**
 * @module BaseLoopBackApi
@@ -845,7 +845,7 @@ let headers = {
           data    : body ? JSON.stringify(body) : undefined
         }
       );
-      return Observable.fromPromise(request)
+      return from(request)
         .map((res) => res.data)
         .catch((e) => errorHandler.handleError(e));
 <% } %>

--- a/lib/templates/shared/services/core/error.ejs
+++ b/lib/templates/shared/services/core/error.ejs
@@ -3,9 +3,7 @@
 import { Injectable } from '@angular/core';
 import { Response } from '@angular/http';
 <% } %>
-import { Observable } from 'rxjs/Observable';
-//import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
-import 'rxjs/add/observable/throw';
+import { Observable, throwError } from 'rxjs';
 /**
  * Default error handler
  */
@@ -13,14 +11,11 @@ import 'rxjs/add/observable/throw';
 @Injectable()
 <% } %>
 export class ErrorHandler {
-  // ErrorObservable when rxjs version < rc.5
-  // ErrorObservable<string> when rxjs version = rc.5
-  // I'm leaving any for now to avoid breaking apps using both versions
-  public handleError(error: Response): any {
+  public handleError(error: Response): Observable<never> {
 <% if (framework === 'react') { -%>
-    return Observable.throw(error.response.data.error || 'Server error');
+    return throwError(error.response.data.error || 'Server error');
 <% } else { -%>
-    return Observable.throw(error.json().error || 'Server error');
+    return throwError(error.json().error || 'Server error');
 <% } %>
   }
 }
@@ -29,9 +24,7 @@ export class ErrorHandler {
 import { Injectable } from '@angular/core';
 import { Response } from '@angular/http';
 <% } %>
-import { Observable } from 'rxjs/Observable';
-//import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
-import 'rxjs/add/observable/throw';
+import { Observable, throwError } from 'rxjs';
 /**
  * Default error handler
  */
@@ -39,14 +32,11 @@ import 'rxjs/add/observable/throw';
 @Injectable()
 <% } %>
 export class ErrorHandler {
-  // ErrorObservable when rxjs version < rc.5
-  // ErrorObservable<string> when rxjs version = rc.5
-  // I'm leaving any for now to avoid breaking apps using both versions
-  handleError(error) {
+  handleError(error): Observable<never> {
 <% if (framework === 'react') { -%>
-    return Observable.throw(error.response.data.error || 'Server error');
+    return throwError(error.response.data.error || 'Server error');
 <% } else { -%>
-    return Observable.throw(error.json().error || 'Server error');
+    return throwError(error.json().error || 'Server error');
 <% } %>
   }
 }

--- a/lib/templates/shared/services/core/io.ejs
+++ b/lib/templates/shared/services/core/io.ejs
@@ -1,5 +1,4 @@
-import { Subject } from 'rxjs/Subject';
-import { Observable } from 'rxjs/Observable';
+import { Observable, Subject } from 'rxjs';
 
 export class IO {
 

--- a/lib/templates/shared/services/core/realtime.ts
+++ b/lib/templates/shared/services/core/realtime.ts
@@ -4,10 +4,8 @@ import { LoopBackAuth } from './auth.service';
 import { FireLoop } from '../../models/FireLoop';
 import { SocketConnection } from '../../sockets/socket.connections';
 import { SDKModels } from '../custom/SDKModels';
-import { Observable } from 'rxjs/Observable';
+import { Observable, Subject, Subscription } from 'rxjs';
 import { share } from 'rxjs/operators';
-import { Subject } from 'rxjs/Subject';
-import { Subscription } from 'rxjs/Subscription';
 /**
 * @author Jonathan Casarrubias <twitter:@johncasarrubias> <github:@johncasarrubias>
 * @module RealTime

--- a/tests/ng2web/src/app/shared/sdk/services/custom/Account.ts
+++ b/tests/ng2web/src/app/shared/sdk/services/custom/Account.ts
@@ -1,0 +1,1357 @@
+/* tslint:disable */
+import { Injectable, Inject, Optional } from '@angular/core';
+import { HttpClient, HttpResponse } from '@angular/common/http';
+import { SDKModels } from './SDKModels';
+import { BaseLoopBackApi } from '../core/base.service';
+import { LoopBackConfig } from '../../lb.config';
+import { LoopBackAuth } from '../core/auth.service';
+import { LoopBackFilter, SDKToken, AccessToken } from '../../models/BaseModels';
+import { ErrorHandler } from '../core/error.service';
+import { Observable, Subject } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Account } from '../../models/Account';
+import { SocketConnection } from '../../sockets/socket.connections';
+import { RoomAccount } from '../../models/RoomAccount';
+import { Room } from '../../models/Room';
+import { RoomAdmin } from '../../models/RoomAdmin';
+
+
+/**
+ * Api services for the `Account` model.
+ */
+@Injectable()
+export class AccountApi extends BaseLoopBackApi {
+
+  constructor(
+    @Inject(HttpClient) protected http: HttpClient,
+    @Inject(SocketConnection) protected connection: SocketConnection,
+    @Inject(SDKModels) protected models: SDKModels,
+    @Inject(LoopBackAuth) protected auth: LoopBackAuth,
+    @Optional() @Inject(ErrorHandler) protected errorHandler: ErrorHandler
+  ) {
+    super(http,  connection,  models, auth, errorHandler);
+  }
+
+  /**
+   * Find a related item by id for accessTokens.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for accessTokens
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public findByIdAccessTokens(id: any, fk: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/accessTokens/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Delete a related item by id for accessTokens.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for accessTokens
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public destroyByIdAccessTokens(id: any, fk: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "DELETE";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/accessTokens/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Update a related item by id for accessTokens.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for accessTokens
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public updateByIdAccessTokens(id: any, fk: any, data: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "PUT";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/accessTokens/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {
+      data: data
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Find a related item by id for rooms.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for rooms
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public findByIdRooms(id: any, fk: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/rooms/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Delete a related item by id for rooms.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for rooms
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public destroyByIdRooms(id: any, fk: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "DELETE";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/rooms/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Update a related item by id for rooms.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for rooms
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public updateByIdRooms(id: any, fk: any, data: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "PUT";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/rooms/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {
+      data: data
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Add a related item by id for rooms.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for rooms
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public linkRooms(id: any, fk: any, data: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "PUT";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/rooms/rel/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {
+      data: data
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Remove the rooms relation to an item by id.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for rooms
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public unlinkRooms(id: any, fk: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "DELETE";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/rooms/rel/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Check the existence of rooms relation to an item by id.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for rooms
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public existsRooms(id: any, fk: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "HEAD";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/rooms/rel/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Find a related item by id for administrations.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for administrations
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public findByIdAdministrations(id: any, fk: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/administrations/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Delete a related item by id for administrations.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for administrations
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public destroyByIdAdministrations(id: any, fk: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "DELETE";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/administrations/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Update a related item by id for administrations.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for administrations
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public updateByIdAdministrations(id: any, fk: any, data: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "PUT";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/administrations/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {
+      data: data
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Add a related item by id for administrations.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for administrations
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public linkAdministrations(id: any, fk: any, data: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "PUT";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/administrations/rel/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {
+      data: data
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Remove the administrations relation to an item by id.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for administrations
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public unlinkAdministrations(id: any, fk: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "DELETE";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/administrations/rel/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Check the existence of administrations relation to an item by id.
+   *
+   * @param {any} id Account id
+   *
+   * @param {any} fk Foreign key for administrations
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public existsAdministrations(id: any, fk: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "HEAD";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/administrations/rel/:fk";
+    let _routeParams: any = {
+      id: id,
+      fk: fk
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Queries accessTokens of Account.
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} filter 
+   *
+   * @returns {object[]} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public getAccessTokens(id: any, filter: LoopBackFilter = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/accessTokens";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    if (typeof filter !== 'undefined' && filter !== null) _urlParams.filter = filter;
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Creates a new instance in accessTokens of this model.
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public createAccessTokens(id: any, data: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "POST";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/accessTokens";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {
+      data: data
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Deletes all accessTokens of this model.
+   *
+   * @param {any} id Account id
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public deleteAccessTokens(id: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "DELETE";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/accessTokens";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Counts accessTokens of Account.
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} where Criteria to match model instances
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * Data properties:
+   *
+   *  - `count` – `{number}` - 
+   */
+  public countAccessTokens(id: any, where: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/accessTokens/count";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    if (typeof where !== 'undefined' && where !== null) _urlParams.where = where;
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Queries rooms of Account.
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} filter 
+   *
+   * @returns {object[]} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public getRooms(id: any, filter: LoopBackFilter = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/rooms";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    if (typeof filter !== 'undefined' && filter !== null) _urlParams.filter = filter;
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Creates a new instance in rooms of this model.
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public createRooms(id: any, data: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "POST";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/rooms";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {
+      data: data
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Deletes all rooms of this model.
+   *
+   * @param {any} id Account id
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public deleteRooms(id: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "DELETE";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/rooms";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Counts rooms of Account.
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} where Criteria to match model instances
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * Data properties:
+   *
+   *  - `count` – `{number}` - 
+   */
+  public countRooms(id: any, where: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/rooms/count";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    if (typeof where !== 'undefined' && where !== null) _urlParams.where = where;
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Queries administrations of Account.
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} filter 
+   *
+   * @returns {object[]} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public getAdministrations(id: any, filter: LoopBackFilter = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/administrations";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    if (typeof filter !== 'undefined' && filter !== null) _urlParams.filter = filter;
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Creates a new instance in administrations of this model.
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public createAdministrations(id: any, data: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "POST";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/administrations";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {
+      data: data
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Deletes all administrations of this model.
+   *
+   * @param {any} id Account id
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public deleteAdministrations(id: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "DELETE";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/administrations";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Counts administrations of Account.
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} where Criteria to match model instances
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * Data properties:
+   *
+   *  - `count` – `{number}` - 
+   */
+  public countAdministrations(id: any, where: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/administrations/count";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    if (typeof where !== 'undefined' && where !== null) _urlParams.where = where;
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Patch an existing model instance or insert a new one into the data source.
+   *
+   * @param {object} data Request data.
+   *
+   *  - `data` – `{object}` - Model instance data
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public patchOrCreate(data: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "PATCH";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts";
+    let _routeParams: any = {};
+    let _postBody: any = {
+      data: data
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Patch attributes for a model instance and persist it into the data source.
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} data Request data.
+   *
+   *  - `data` – `{object}` - An object of model property name/value pairs
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public patchAttributes(id: any, data: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "PATCH";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {
+      data: data
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Login a user with username/email and password.
+   *
+   * @param {string} include Related objects to include in the response. See the description of return value for more details.
+   *   Default value: `user`.
+   *
+   *  - `rememberMe` - `boolean` - Whether the authentication credentials
+   *     should be remembered in localStorage across app/browser restarts.
+   *     Default: `true`.
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * The response body contains properties of the AccessToken created on login.
+   * Depending on the value of `include` parameter, the body may contain additional properties:
+   * 
+   *   - `user` - `U+007BUserU+007D` - Data of the currently logged in user. (`include=user`)
+   * 
+   *
+   */
+  public login(credentials: any, include: any = 'user', rememberMe: boolean = true, customHeaders?: Function): Observable<any> {
+    let _method: string = "POST";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/login";
+    let _routeParams: any = {};
+    let _postBody: any = {
+      credentials: credentials
+    };
+    let _urlParams: any = {};
+    if (typeof include !== 'undefined' && include !== null) _urlParams.include = include;
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders)
+      .pipe(
+        map(
+        (response: any) => {
+          response.ttl = parseInt(response.ttl);
+          response.rememberMe = rememberMe;
+          this.auth.setToken(response);
+          return response;
+        }
+      )
+      );
+      return result;
+      
+  }
+
+  /**
+   * Logout a user with access token.
+   *
+   * @param {object} data Request data.
+   *
+   * This method does not accept any data. Supply an empty object.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public logout(customHeaders?: Function): Observable<any> {
+    let _method: string = "POST";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/logout";
+    let _routeParams: any = {};
+    let _postBody: any = {};
+    let _urlParams: any = {};
+       _urlParams.access_token = this.auth.getAccessTokenId();
+    this.auth.clear(); 
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Trigger user's identity verification with configured verifyOptions
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} data Request data.
+   *
+   * This method does not accept any data. Supply an empty object.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public verify(id: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "POST";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/verify";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Confirm a user registration with identity verification token.
+   *
+   * @param {string} uid 
+   *
+   * @param {string} token 
+   *
+   * @param {string} redirect 
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public confirm(uid: any, token: any, redirect: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/confirm";
+    let _routeParams: any = {};
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    if (typeof uid !== 'undefined' && uid !== null) _urlParams.uid = uid;
+    if (typeof token !== 'undefined' && token !== null) _urlParams.token = token;
+    if (typeof redirect !== 'undefined' && redirect !== null) _urlParams.redirect = redirect;
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Reset password for a user with email.
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public resetPassword(options: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "POST";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/reset";
+    let _routeParams: any = {};
+    let _postBody: any = {
+      options: options
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Change a user's password.
+   *
+   * @param {object} data Request data.
+   *
+   *  - `oldPassword` – `{string}` - 
+   *
+   *  - `newPassword` – `{string}` - 
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public changePassword(oldPassword: any, newPassword: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "POST";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/change-password";
+    let _routeParams: any = {};
+    let _postBody: any = {
+      data: {
+        oldPassword: oldPassword,
+        newPassword: newPassword
+      }
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Reset user's password via a password-reset token.
+   *
+   * @param {object} data Request data.
+   *
+   *  - `newPassword` – `{string}` - 
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * This method returns no data.
+   */
+  public setPassword(newPassword: any, customHeaders?: Function): Observable<any> {
+    let _method: string = "POST";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/reset-password";
+    let _routeParams: any = {};
+    let _postBody: any = {
+      data: {
+        newPassword: newPassword
+      }
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * <em>
+         * (The remote method definition does not provide any description.)
+         * </em>
+   *
+   * @returns {object} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * Data properties:
+   *
+   *  - `result` – `{any}` - 
+   */
+  public myRemote(customHeaders?: Function): Observable<any> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/my-remote";
+    let _routeParams: any = {};
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Statistical information for Account registers.
+   *
+   * @param {string} range hourly, daily, weekly, monthly, yearly, custom
+   *
+   * @param {object} custom {"start": date, "end": date }
+   *
+   * @param {object} where where filter 
+   *
+   * @param {string} groupBy group by filter 
+   *
+   * @returns {object[]} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public stats(range: any, custom: any = {}, where: any = {}, groupBy: any = {}, customHeaders?: Function): Observable<any> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/stats";
+    let _routeParams: any = {};
+    let _postBody: any = {};
+    let _urlParams: any = {};
+    if (typeof range !== 'undefined' && range !== null) _urlParams.range = range;
+    if (typeof custom !== 'undefined' && custom !== null) _urlParams.custom = custom;
+    if (typeof where !== 'undefined' && where !== null) _urlParams.where = where;
+    if (typeof groupBy !== 'undefined' && groupBy !== null) _urlParams.groupBy = groupBy;
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Creates a new instance in accessTokens of this model.
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object[]} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public createManyAccessTokens(id: any, data: any[] = [], customHeaders?: Function): Observable<any> {
+    let _method: string = "POST";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/accessTokens";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {
+      data: data
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Creates a new instance in rooms of this model.
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object[]} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public createManyRooms(id: any, data: any[] = [], customHeaders?: Function): Observable<any> {
+    let _method: string = "POST";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/rooms";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {
+      data: data
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+
+  /**
+   * Creates a new instance in administrations of this model.
+   *
+   * @param {any} id Account id
+   *
+   * @param {object} data Request data.
+   *
+   * This method expects a subset of model properties as request parameters.
+   *
+   * @returns {object[]} An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   *
+   * <em>
+   * (The remote method definition does not provide any description.
+   * This usually means the response is a `Account` object.)
+   * </em>
+   */
+  public createManyAdministrations(id: any, data: any[] = [], customHeaders?: Function): Observable<any> {
+    let _method: string = "POST";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() +
+    "/accounts/:id/administrations";
+    let _routeParams: any = {
+      id: id
+    };
+    let _postBody: any = {
+      data: data
+    };
+    let _urlParams: any = {};
+    let result = this.request(_method, _url, _routeParams, _urlParams, _postBody, null, customHeaders);
+    return result;
+  }
+  /**
+   * @ngdoc method
+   * @name sdk.Account#getCurrent
+   * @methodOf sdk.Account
+   *
+   * @description
+   *
+   * Get data of the currently logged user. Fail with HTTP result 401
+   * when there is no user logged in.
+   *
+   * @returns object An empty reference that will be
+   *   populated with the actual data once the response is returned
+   *   from the server.
+   */
+  public getCurrent(filter: LoopBackFilter = {}): Observable<any> {
+    let _method: string = "GET";
+    let _url: string = LoopBackConfig.getPath() + "/" + LoopBackConfig.getApiVersion() + "/accounts" + "/:id";
+    let id: any = this.auth.getCurrentUserId();
+    if (id == null)
+    id = '__anonymous__';
+    let _routeParams: any = { id: id };
+    let _urlParams: any = {};
+    let _postBody: any = {};
+    if (filter) _urlParams.filter = filter;
+    return this.request(_method, _url, _routeParams, _urlParams, _postBody);
+  }
+  /**
+   * Get data of the currently logged user that was returned by the last
+   * call to {@link sdk.Account#login} or
+   * {@link sdk.Account#getCurrent}. Return null when there
+   * is no user logged in or the data of the current user were not fetched
+   * yet.
+   *
+   * @returns object An Account instance.
+   */
+  public getCachedCurrent() {
+    return this.auth.getCurrentUserData();
+  }
+  /**
+   * Get data of the currently logged access tokern that was returned by the last
+   * call to {@link sdk.Account#login}
+   *
+   * @returns object An AccessToken instance.
+   */
+  public getCurrentToken(): AccessToken {
+    return this.auth.getToken();
+  }
+  /**
+   * @name sdk.Account#isAuthenticated
+   *
+   * @returns {boolean} True if the current user is authenticated (logged in).
+   */
+  public isAuthenticated() {
+    return !(this.getCurrentId() === '' || this.getCurrentId() == null || this.getCurrentId() == 'null');
+  }
+
+  /**
+   * @name sdk.Account#getCurrentId
+   *
+   * @returns object Id of the currently logged-in user or null.
+   */
+  public getCurrentId() {
+    return this.auth.getCurrentUserId();
+  }
+
+  /**
+   * The name of the model represented by this $resource,
+   * i.e. `Account`.
+   */
+  public getModelName() {
+    return "Account";
+  }
+}


### PR DESCRIPTION
All RxJS imports follow the new v6+ importing scheme for tree-shaking and compatibility with Angular v6.

Fixes #594

#### What type of pull request are you creating?
- [ ] Bug Fix
- [x] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?
None

Write a reason if none (e.g just fixed a typo):
No functionality added

#### Please add a description for your pull request:
Migrates all rxjs imports to tree-shakable (importing from `rxjs` and `rxjs/operators` only) to comply with RxJS 6, Angular 6.

It is still compatible with the previous required RxJS version (5.5.9).