### PR TITLE
Change `socket.io-client` import statement for namespace error

### DIFF
--- a/lib/angular2/shared/sockets/socket.browser.ts
+++ b/lib/angular2/shared/sockets/socket.browser.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
-import * as io from 'socket.io-client';
+import * as ioImported from 'socket.io-client';
+const io = ioImported;
 /**
 * @author Jonathan Casarrubias <twitter:@johncasarrubias> <github:@mean-expert-official>
 * @module SocketBrowser


### PR DESCRIPTION
refs https://github.com/mean-expert-official/loopback-sdk-builder/issues/603

#### What type of pull request are you creating?
- [x] Bug Fix
- [x] Enhancement
- [ ] Documentation

#### How many unit test did you write for this pull request?
None

Write a reason if none (e.g just fixed a typo):
just change import statement

#### Please add a description for your pull request:
Fix error when roll up angular module include loopback sdk 
refs #603 