### PR TITLE
fix: read property error of undefined when DOMException occured

### DIFF
--- a/lib/angular2/shared/services/core/error.ejs
+++ b/lib/angular2/shared/services/core/error.ejs
@@ -8,6 +8,8 @@ import { Observable, throwError } from 'rxjs';
 @Injectable()
 export class ErrorHandler {
   public handleError(errorResponse: HttpErrorResponse): Observable<never> {
-    return throwError(errorResponse.error.error || 'Server error');
+    return throwError(
+      (errorResponse.error && errorResponse.error.error) || 'Server error',
+    );
   }
 }


### PR DESCRIPTION
#### What type of issue are you creating?
- [x] Bug
- [ ] Enhancement
- [ ] Question

#### What version of this module are you using?
- [ ] 2.0.10 (Stable)
- [ ] 2.1.0-rc.n (2.1 Release Candidate n)
- [x] Other

Write other if any:

#### Please add a description for your issue:

I passed a wrong baseUrl to config accidently

```
const baseUrl = window.location.host;
LoopBackConfig.setBaseUrl(baseUrl);
```

when I call api, an DOMException error occured, and report the error as title.
The DOMException error message is 
```
DOMException: Failed to execute 'open' on 'XMLHttpRequest': Invalid URL
```

Related code:
[LINK](https://github.com/mean-expert-official/loopback-sdk-builder/blob/d3041e443ed9683a96dbbbb4330e9f8d632f81a3/lib/angular2/shared/services/core/error.ejs#L11)

we should make sure `errorResponse.error` exists, PTAL